### PR TITLE
Fixes upload by disabling import of empty or whitespace labels

### DIFF
--- a/controller/transfer/record_transfer_manager.py
+++ b/controller/transfer/record_transfer_manager.py
@@ -237,6 +237,11 @@ def split_record_data_and_label_data(
         label_data = {}
         for imported_key, item in data_item.items():
             if "__" in imported_key:
+                if (
+                    item.strip() == ""
+                ):  # if a label is only consists of whitespaces or is empty continue
+                    continue
+
                 task_name = controller.labeling_task.util.infer_labeling_task_name(
                     imported_key
                 )


### PR DESCRIPTION
Test with refinery respectively with release state

While uploading with records with and without labels it could come to
the sitation where records got labeled with empty values

solves https://github.com/code-kern-ai/refinery-gateway/issues/5

sample data sets which should now work
[label-bug.json.zip](https://github.com/code-kern-ai/refinery-gateway/files/9180669/label-bug.json.zip)
[clickbait mini 2 - Labels and non-labels.json.zip](https://github.com/code-kern-ai/refinery-gateway/files/9180672/clickbait.mini.2.-.Labels.and.non-labels.json.zip)

