### PR TITLE
adds confidence charts

### DIFF
--- a/controller/project/manager.py
+++ b/controller/project/manager.py
@@ -106,6 +106,17 @@ def get_label_distribution(
     return project.get_label_distribution(project_id, labeling_task_id, slice_id)
 
 
+def get_confidence_distribution(
+    project_id: str,
+    labeling_task_id: str,
+    slice_id: str = None,
+    num_samples: int = None,
+) -> str:
+    return project.get_confidence_distribution(
+        project_id, labeling_task_id, slice_id, num_samples
+    )
+
+
 def get_confusion_matrix(
     project_id: str,
     labeling_task_id: str,

--- a/controller/project/manager.py
+++ b/controller/project/manager.py
@@ -109,8 +109,8 @@ def get_label_distribution(
 def get_confidence_distribution(
     project_id: str,
     labeling_task_id: str,
-    slice_id: str = None,
-    num_samples: int = None,
+    slice_id: Optional[str] = None,
+    num_samples: Optional[int] = None,
 ) -> str:
     return project.get_confidence_distribution(
         project_id, labeling_task_id, slice_id, num_samples

--- a/graphql_api/query/project.py
+++ b/graphql_api/query/project.py
@@ -13,7 +13,6 @@ from util.inter_annotator.functions import (
     resolve_inter_annotator_matrix_classification,
     resolve_inter_annotator_matrix_extraction,
 )
-from graphql_api import types
 
 
 class ProjectQuery(graphene.ObjectType):
@@ -157,8 +156,8 @@ class ProjectQuery(graphene.ObjectType):
         self,
         info,
         project_id: str,
-        labeling_task_id: str = None,
-        slice_id: str = None,
+        labeling_task_id: Optional[str] = None,
+        slice_id: Optional[str] = None,
         num_samples: int = 100,
     ) -> List:
         auth.check_demo_access(info)

--- a/graphql_api/query/project.py
+++ b/graphql_api/query/project.py
@@ -13,6 +13,7 @@ from util.inter_annotator.functions import (
     resolve_inter_annotator_matrix_classification,
     resolve_inter_annotator_matrix_extraction,
 )
+from graphql_api import types
 
 
 class ProjectQuery(graphene.ObjectType):
@@ -50,6 +51,13 @@ class ProjectQuery(graphene.ObjectType):
         slice_id=graphene.ID(required=False),
     )
     label_distribution = graphene.Field(
+        graphene.JSONString,
+        project_id=graphene.ID(required=True),
+        labeling_task_id=graphene.ID(required=False),
+        slice_id=graphene.ID(required=False),
+    )
+
+    confidence_distribution = graphene.Field(
         graphene.JSONString,
         project_id=graphene.ID(required=True),
         labeling_task_id=graphene.ID(required=False),
@@ -144,6 +152,21 @@ class ProjectQuery(graphene.ObjectType):
         auth.check_demo_access(info)
         auth.check_project_access(info, project_id)
         return manager.get_label_distribution(project_id, labeling_task_id, slice_id)
+
+    def resolve_confidence_distribution(
+        self,
+        info,
+        project_id: str,
+        labeling_task_id: str = None,
+        slice_id: str = None,
+        num_samples: int = 100,
+    ) -> List:
+        auth.check_demo_access(info)
+        auth.check_project_access(info, project_id)
+        confidence_scores = manager.get_confidence_distribution(
+            project_id, labeling_task_id, slice_id, num_samples
+        )
+        return confidence_scores
 
     def resolve_confusion_matrix(
         self,

--- a/graphql_api/types.py
+++ b/graphql_api/types.py
@@ -1,4 +1,3 @@
-from importlib.metadata import distribution
 import json
 import datetime
 import decimal

--- a/graphql_api/types.py
+++ b/graphql_api/types.py
@@ -1,3 +1,4 @@
+from importlib.metadata import distribution
 import json
 import datetime
 import decimal
@@ -15,6 +16,7 @@ from submodules.model.business_objects import (
     attribute,
     information_source,
     labeling_task,
+    project,
 )
 from submodules.model import models
 from util import notification
@@ -297,6 +299,7 @@ class LabelingTask(SQLAlchemyObjectType):
     # TODO: can these now be removed ?
     confusion_matrix = graphene.Field(graphene.List(ConfusionMatrixElement))
     inter_annotator_matrix = graphene.Field(InterAnnotatorMatrix)
+    confidence_distribution = graphene.JSONString()
 
     @staticmethod
     def _resolve_record_classifications(label_id, label_source, self):
@@ -419,6 +422,12 @@ class LabelingTask(SQLAlchemyObjectType):
             return resolve_inter_annotator_matrix_extraction(self, True, False, None)
 
         raise ValueError(f"Can't match task type {self.task_type}")
+
+    def resolve_confidence_distribution(self, info):
+        confidence_scores = project.get_confidence_distribution(
+            self.project_id, self.id, num_samples=100
+        )
+        return confidence_scores
 
 
 class InformationSource(SQLAlchemyObjectType):


### PR DESCRIPTION
use [submodule](https://github.com/code-kern-ai/refinery-submodule-model/pull/10) and [frontend](https://github.com/code-kern-ai/refinery-ui/pull/60) from this branch.

When you jump into the clickbait project, you should see a confidence distribution chart on the overview page