### PR TITLE
avoid setting overlapping extraction labels

### DIFF
--- a/controller/record_label_association/manager.py
+++ b/controller/record_label_association/manager.py
@@ -111,7 +111,31 @@ def create_manual_extraction_label(
     if label_item is None:
         return None
 
-    tokens = record_label_association.create_token_objects(
+    existing_tokens = record_label_association.get_manual_tokens_by_record_id(record_id)
+
+    tokens = []
+    curr_start = None
+    curr_end = None
+    for existing_token in existing_tokens:
+        if existing_token.is_beginning_token:
+            if curr_start is not None:
+                tokens.append([curr_start, curr_end])
+            curr_start = existing_token.token_index
+        curr_end = existing_token.token_index
+    if curr_start is not None:
+        tokens.append([curr_start, curr_end])
+
+    # avoid overlapping tokens
+    for token in tokens:
+        if (
+            token[0] <= token_start_index <= token[1]
+            or token[0] <= token_end_index <= token[1]
+            or token_start_index <= token[0] <= token_end_index
+            or token_start_index <= token[1] <= token_end_index
+        ):
+            return record_item
+
+    new_tokens = record_label_association.create_token_objects(
         project_id, token_start_index, token_end_index + 1
     )
     record_label_association.create(
@@ -122,7 +146,7 @@ def create_manual_extraction_label(
         enums.LabelSource.MANUAL.value,
         enums.InformationSourceReturnType.YIELD.value,
         as_gold_star,
-        tokens,
+        new_tokens,
         with_commit=True,
     )
     update_is_relevant_manual_label(


### PR DESCRIPTION
together with [frontend](https://github.com/code-kern-ai/refinery-ui/pull/57) and [submodule](https://github.com/code-kern-ai/refinery-submodule-model/pull/11)