### PR TITLE
Allow records to be imported where the pk field name contains spaces.

### DIFF
--- a/controller/transfer/checks.py
+++ b/controller/transfer/checks.py
@@ -193,7 +193,7 @@ def build_df_sql(project_id: str) -> Tuple[str, List[str]]:
     sql = "SELECT id record_id"
     keys = []
     for att in primary_keys:
-        sql += f", r.data->>'{att.name}' {att.name}"
+        sql += f", r.data->>'{att.name}' \"{att.name}\""
         keys.append(att.name)
     sql += f"\nFROM record r WHERE project_id = '{project_id}'"
     return sql, keys


### PR DESCRIPTION
Currently this fails with the error:
```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError) syntax error at or near "Id"
LINE 1: SELECT id record_id, r.data->>'Display Id' Display Id
                                                           ^

[SQL: SELECT id record_id, r.data->>'Display Id' Display Id
FROM record r WHERE project_id = 'b457cf86-62e0-4049-92cd-1ddb68814a72']
(Background on this error at: https://sqlalche.me/e/14/f405)
```

I think there may still be issues with the record import, will raise a separate issue for this.