### PR TITLE
Fixes record upload logic for record upload

### DIFF
--- a/controller/transfer/record_transfer_manager.py
+++ b/controller/transfer/record_transfer_manager.py
@@ -66,7 +66,7 @@ def import_records_and_rlas(
         
         if idx == 0:
             create_attributes_and_get_text_attributes(project_id, records_data)
-        primary_keys = attribute.get_primary_keys(project_id)
+            primary_keys = attribute.get_primary_keys(project_id)
 
         import_labeling_tasks_and_labels_pipeline(
             project_id=project_id, tasks_data=tasks_data

--- a/controller/transfer/record_transfer_manager.py
+++ b/controller/transfer/record_transfer_manager.py
@@ -63,11 +63,10 @@ def import_records_and_rlas(
             labels_data,
             tasks_data,
         ) = split_record_data_and_label_data(chunk)
-
-        primary_keys = None
+        
         if idx == 0:
             create_attributes_and_get_text_attributes(project_id, records_data)
-            primary_keys = attribute.get_primary_keys(project_id)
+        primary_keys = attribute.get_primary_keys(project_id)
 
         import_labeling_tasks_and_labels_pipeline(
             project_id=project_id, tasks_data=tasks_data


### PR DESCRIPTION
Fixes record upload logic for second and following chunks by making the primary keys available in later chunks too

closes [[BUG] - Primary key update logic seems faulty #105](https://github.com/code-kern-ai/refinery/issues/105)

Steps to solve:

1. analyze and understand error (1-2 hours)
2. If easy to fix, continue / if hard to fix, reevaluate time estimations (15 min)
3. Create Branch and PR, setup implementation (15 min)
4. Implement fix (1 hour)
5. Test fixes (1 hour)
6. Review PR (1 hour)
7. Merge changes and close issue (15 min)

-> 6-7 hour estimation + 1 hour of buffer, so roughly a day in total

Datasets to reproduce and test: [test-sets.zip](https://github.com/code-kern-ai/refinery-gateway/files/9775463/test-sets.zip)

The bug occurs on the 500th record and following ones because primary keys got only read for the first chunk. Made the primary keys available for following chunks.

Further finding: If a record gets uploaded with a new attribute (which is not yet present in the project) it gets created and all of the other records get an empty attribute field added . Don't know yet if this is an issue at all or is wanted, so @JWittmeyer maybe we have to talk about this, because if this is not wanted it could maybe solved in this PR, too! Can be reproduced by creating a sample Clickbait project and then upload the dataset "clickbait_abc_extension_1.json" out of the referenced [test-sets.zip](https://github.com/code-kern-ai/refinery-gateway/files/9775463/test-sets.zip)/1 into the clickbait project.


