### PR TITLE
create workflow project from REST API instead of GQL

### DIFF
--- a/api/project.py
+++ b/api/project.py
@@ -67,8 +67,11 @@ class ProjectCreationFromWorkflow(HTTPEndpoint):
             organization.id, name, description, user.id
         )
         project_manager.update_project(project_id=project.id, tokenizer=tokenizer)
+        data = adapter.get_records_from_store(store_id)
+        adapter.check(data, project.id, user.id)
+
         project_manager.add_workflow_store_data_to_project(
-            store_id=store_id, user_id=user.id, project_id=project.id, file_name=name
+            user_id=user.id, project_id=project.id, file_name=name, data=data
         )
 
         tokenization_service.request_tokenize_project(str(project.id), str(user.id))

--- a/api/project.py
+++ b/api/project.py
@@ -7,6 +7,29 @@ from controller.project import manager as project_manager
 from controller.attribute import manager as attribute_manager
 from submodules.model import exceptions
 
+import os
+from controller.tokenization import tokenization_service
+from submodules.model import enums, events
+from submodules.s3.controller import bucket_exists, create_bucket
+from util import doc_ock, notification
+from controller.transfer.record_transfer_manager import import_records_and_rlas
+from controller.transfer.manager import check_and_add_running_id
+from controller.auth import manager as auth_manager
+from controller.project import manager as project_manager
+from controller.upload_task import manager as upload_task_manager
+from submodules.model import enums
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+__engine = None
+
+
+def get_workflow_db_engine():
+    global __engine
+    if __engine is None:
+        __engine = create_engine(os.getenv("WORKFLOW_POSTGRES"))
+    return __engine
+
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -41,3 +64,62 @@ class ProjectDetails(HTTPEndpoint):
             "knowledge_base_ids": [str(list.id) for list in project.knowledge_bases],
         }
         return JSONResponse(result)
+
+
+class ProjectCreationFromWorkflow(HTTPEndpoint):
+    async def post(self, request) -> JSONResponse:
+        user_id = request.query_params["user_id"]
+        request_body = await request.json()
+        name = request_body["name"]
+        description = request_body["description"]
+        tokenizer = request_body["tokenizer"]
+        store_id = request_body["store_id"]
+
+        user = auth_manager.get_user_by_id(user_id)
+        organization = auth_manager.get_organization_by_user_id(user.id)
+
+        if not bucket_exists(str(organization.id)):
+            create_bucket(str(organization.id))
+
+        project = project_manager.create_project(
+            organization.id, name, description, user.id
+        )
+        project_manager.update_project(project_id=project.id, tokenizer=tokenizer)
+
+        Session = sessionmaker(get_workflow_db_engine())
+        with Session() as session:
+            results = session.execute(
+                f"SELECT record FROM store_entry WHERE store_id = '{store_id}'"
+            ).all()
+
+        data = [result for result, in results]
+
+        upload_task = upload_task_manager.create_upload_task(
+            user_id=user.id,
+            project_id=project.id,
+            file_name=name,
+            file_type="json",
+            file_import_options="",
+            upload_type=enums.UploadTypes.WORKFLOW_STORE.value,
+        )
+        import_records_and_rlas(
+            project.id,
+            user.id,
+            data,
+            upload_task,
+            enums.RecordCategory.SCALE.value,
+        )
+        check_and_add_running_id(project.id, user.id)
+
+        upload_task_manager.update_upload_task_to_finished(upload_task)
+        tokenization_service.request_tokenize_project(str(project.id), str(user.id))
+
+        notification.send_organization_update(
+            project.id, f"project_created:{str(project.id)}", True
+        )
+        doc_ock.post_event(
+            user,
+            events.CreateProject(Name=f"{name}-{project.id}", Description=description),
+        )
+
+        return JSONResponse({"project_id": str(project.id)})

--- a/api/project.py
+++ b/api/project.py
@@ -7,29 +7,10 @@ from controller.project import manager as project_manager
 from controller.attribute import manager as attribute_manager
 from submodules.model import exceptions
 
-import os
 from controller.tokenization import tokenization_service
-from submodules.model import enums, events
+from submodules.model import events
 from submodules.s3.controller import bucket_exists, create_bucket
-from util import doc_ock, notification
-from controller.transfer.record_transfer_manager import import_records_and_rlas
-from controller.transfer.manager import check_and_add_running_id
-from controller.auth import manager as auth_manager
-from controller.project import manager as project_manager
-from controller.upload_task import manager as upload_task_manager
-from submodules.model import enums
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
-__engine = None
-
-
-def get_workflow_db_engine():
-    global __engine
-    if __engine is None:
-        __engine = create_engine(os.getenv("WORKFLOW_POSTGRES"))
-    return __engine
-
+from util import doc_ock, notification, adapter
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -67,13 +48,14 @@ class ProjectDetails(HTTPEndpoint):
 
 
 class ProjectCreationFromWorkflow(HTTPEndpoint):
-    async def post(self, request) -> JSONResponse:
-        user_id = request.query_params["user_id"]
-        request_body = await request.json()
-        name = request_body["name"]
-        description = request_body["description"]
-        tokenizer = request_body["tokenizer"]
-        store_id = request_body["store_id"]
+    async def post(self, request_body) -> JSONResponse:
+        (
+            user_id,
+            name,
+            description,
+            tokenizer,
+            store_id,
+        ) = await adapter.unpack_request_body(request_body)
 
         user = auth_manager.get_user_by_id(user_id)
         organization = auth_manager.get_organization_by_user_id(user.id)
@@ -85,33 +67,10 @@ class ProjectCreationFromWorkflow(HTTPEndpoint):
             organization.id, name, description, user.id
         )
         project_manager.update_project(project_id=project.id, tokenizer=tokenizer)
-
-        Session = sessionmaker(get_workflow_db_engine())
-        with Session() as session:
-            results = session.execute(
-                f"SELECT record FROM store_entry WHERE store_id = '{store_id}'"
-            ).all()
-
-        data = [result for result, in results]
-
-        upload_task = upload_task_manager.create_upload_task(
-            user_id=user.id,
-            project_id=project.id,
-            file_name=name,
-            file_type="json",
-            file_import_options="",
-            upload_type=enums.UploadTypes.WORKFLOW_STORE.value,
+        project_manager.add_workflow_store_data_to_project(
+            store_id=store_id, user_id=user.id, project_id=project.id, file_name=name
         )
-        import_records_and_rlas(
-            project.id,
-            user.id,
-            data,
-            upload_task,
-            enums.RecordCategory.SCALE.value,
-        )
-        check_and_add_running_id(project.id, user.id)
 
-        upload_task_manager.update_upload_task_to_finished(upload_task)
         tokenization_service.request_tokenize_project(str(project.id), str(user.id))
 
         notification.send_organization_update(

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import logging
 import graphene
-from api.project import ProjectDetails
+from api.project import ProjectDetails, ProjectCreationFromWorkflow
 from api.transfer import (
     AssociationsImport,
     FileExport,
@@ -40,6 +40,7 @@ routes = [
     Route("/project/{project_id:str}/import_file", PrepareFileImport),
     Route("/project/{project_id:str}/import_json", JSONImport),
     Route("/project/{project_id:str}/import/task/{task_id:str}", UploadTask),
+    Route("/project", ProjectCreationFromWorkflow),  # create fro workflow
 ]
 
 middleware = [Middleware(DatabaseSessionHandler)]

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ routes = [
     Route("/project/{project_id:str}/import_file", PrepareFileImport),
     Route("/project/{project_id:str}/import_json", JSONImport),
     Route("/project/{project_id:str}/import/task/{task_id:str}", UploadTask),
-    Route("/project", ProjectCreationFromWorkflow),  # create fro workflow
+    Route("/project", ProjectCreationFromWorkflow),
 ]
 
 middleware = [Middleware(DatabaseSessionHandler)]

--- a/controller/auth/manager.py
+++ b/controller/auth/manager.py
@@ -26,6 +26,10 @@ def get_user_by_info(info) -> User:
     return user_manager.get_or_create_user(user_id)
 
 
+def get_user_by_id(user_id: str) -> User:
+    return user_manager.get_or_create_user(user_id)
+
+
 def get_user_by_email(email: str) -> User:
     return user_manager.get_or_create_user_by_email(email)
 

--- a/controller/project/manager.py
+++ b/controller/project/manager.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import time
 import threading
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from graphql import GraphQLError
 
 from controller.transfer import project_transfer_manager as handler
@@ -248,11 +248,8 @@ def __get_first_data_id(project_id: str, user_id: str, huddle_type: str) -> str:
 
 
 def add_workflow_store_data_to_project(
-    store_id: str, project_id: str, user_id: str, file_name: str
+    project_id: str, user_id: str, file_name: str, data: List[Dict[str, Any]]
 ):
-
-    data = adapter.get_records_from_store(store_id)
-
     upload_task = upload_task_manager.create_upload_task(
         user_id=user_id,
         project_id=project_id,

--- a/controller/project/manager.py
+++ b/controller/project/manager.py
@@ -35,6 +35,11 @@ from controller.embedding.connector import (
 )
 from controller.embedding.util import has_encoder_running
 from controller.payload import manager as payload_manager
+from controller.transfer.record_transfer_manager import import_records_and_rlas
+from controller.transfer.manager import check_and_add_running_id
+from controller.upload_task import manager as upload_task_manager
+from submodules.model import enums
+from util import adapter
 
 
 def get_project(project_id: str) -> Project:
@@ -237,6 +242,35 @@ def __get_first_data_id(project_id: str, user_id: str, huddle_type: str) -> str:
         return information_source.get_first_crowd_is_for_annotator(project_id, user_id)
     else:
         raise ValueError("invalid huddle type")
+
+
+# WORKFLOW
+
+
+def add_workflow_store_data_to_project(
+    store_id: str, project_id: str, user_id: str, file_name: str
+):
+
+    data = adapter.get_records_from_store(store_id)
+
+    upload_task = upload_task_manager.create_upload_task(
+        user_id=user_id,
+        project_id=project_id,
+        file_name=file_name,
+        file_type=enums.RecordImportFileTypes.JSON.value,
+        file_import_options="",
+        upload_type=enums.UploadTypes.WORKFLOW_STORE.value,
+    )
+    import_records_and_rlas(
+        project_id,
+        user_id,
+        data,
+        upload_task,
+        enums.RecordCategory.SCALE.value,
+    )
+    check_and_add_running_id(project_id, user_id)
+
+    upload_task_manager.update_upload_task_to_finished(upload_task)
 
 
 # GATES

--- a/controller/transfer/manager.py
+++ b/controller/transfer/manager.py
@@ -88,6 +88,7 @@ def import_records_from_json(
             f"{file_path}",
             "records",
             "",
+            upload_type=enums.UploadTypes.WORKFLOW_STORE.value,
         )
         upload_path = f"{project_id}/{str(upload_task.id)}/{file_path}"
         s3.upload_object(organization_id, upload_path, file_path)

--- a/graphql_api/mutation/project.py
+++ b/graphql_api/mutation/project.py
@@ -1,36 +1,14 @@
-import os
 from typing import Optional
-from controller.tokenization import tokenization_service
 
 import graphene
 
 from controller.auth import manager as auth
-from graphql_api import types
 from graphql_api.types import Project
 from submodules.model import enums, events
 from controller.project import manager
-from submodules.s3.controller import bucket_exists, create_bucket
 from util import doc_ock, notification
 from submodules.model.business_objects import notification as notification_model
-
-
-from controller.transfer.record_transfer_manager import import_records_and_rlas
-from controller.transfer.manager import check_and_add_running_id
-from controller.auth import manager as auth_manager
-from controller.project import manager as project_manager
-from controller.upload_task import manager as upload_task_manager
 from submodules.model import enums
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
-__engine = None
-
-
-def get_workflow_db_engine():
-    global __engine
-    if __engine is None:
-        __engine = create_engine(os.getenv("WORKFLOW_POSTGRES"))
-    return __engine
 
 
 class CreateProject(graphene.Mutation):
@@ -56,67 +34,6 @@ class CreateProject(graphene.Mutation):
             events.CreateProject(Name=f"{name}-{project.id}", Description=description),
         )
         return CreateProject(project=project, ok=True)
-
-
-class CreateProjectByWorkflowStore(graphene.Mutation):
-    class Arguments:
-        name = graphene.String(required=True)
-        description = graphene.String(required=True)
-        tokenizer = graphene.String(required=True)
-        storeId = graphene.String(required=True)
-
-    ok = graphene.Boolean()
-    project = graphene.Field(lambda: Project)
-
-    def mutate(self, info, name: str, description: str, tokenizer: str, storeId: str):
-        user = auth.get_user_by_info(info)
-        organization = auth_manager.get_organization_by_user_id(user.id)
-
-        if not bucket_exists(str(organization.id)):
-            create_bucket(str(organization.id))
-
-        project = project_manager.create_project(
-            organization.id, name, description, user.id
-        )
-        project_manager.update_project(project_id=project.id, tokenizer=tokenizer)
-
-        Session = sessionmaker(get_workflow_db_engine())
-        with Session() as session:
-            results = session.execute(
-                f"SELECT record FROM store_entry WHERE store_id = '{storeId}'"
-            ).all()
-
-        data = [result for result, in results]
-
-        upload_task = upload_task_manager.create_upload_task(
-            user_id=user.id,
-            project_id=project.id,
-            file_name=name,
-            file_type="json",
-            file_import_options="",
-            upload_type=enums.UploadTypes.WORKFLOW_STORE.value,
-        )
-        import_records_and_rlas(
-            project.id,
-            user.id,
-            data,
-            upload_task,
-            enums.RecordCategory.SCALE.value,
-        )
-        check_and_add_running_id(project.id, user.id)
-
-        upload_task_manager.update_upload_task_to_finished(upload_task)
-        tokenization_service.request_tokenize_project(str(project.id), str(user.id))
-
-        notification.send_organization_update(
-            project.id, f"project_created:{str(project.id)}", True
-        )
-        doc_ock.post_event(
-            user,
-            events.CreateProject(Name=f"{name}-{project.id}", Description=description),
-        )
-
-        return CreateProjectByWorkflowStore(project=project, ok=True)
 
 
 class CreateSampleProject(graphene.Mutation):
@@ -224,7 +141,6 @@ class UpdateProjectTokenizer(graphene.Mutation):
 
 class ProjectMutation(graphene.ObjectType):
     create_project = CreateProject.Field()
-    create_project_by_workflow_store = CreateProjectByWorkflowStore.Field()
     create_sample_project = CreateSampleProject.Field()
     delete_project = DeleteProject.Field()
     update_project_status = UpdateProjectStatus.Field()

--- a/util/adapter.py
+++ b/util/adapter.py
@@ -2,7 +2,9 @@ import os
 from typing import List, Dict, Any
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+import pandas as pd
 
+from controller.transfer.checks import run_checks, run_limit_checks
 
 __engine = None
 
@@ -33,3 +35,9 @@ def get_records_from_store(store_id: str) -> List[Dict[str, Any]]:
 
     record_dict_list = [result for result, in record_entity_list]
     return record_dict_list
+
+
+def check(data, project_id, user_id):
+    df = pd.DataFrame(data)
+    run_checks(df, project_id, user_id)
+    run_limit_checks(df, project_id, user_id)

--- a/util/adapter.py
+++ b/util/adapter.py
@@ -1,0 +1,35 @@
+import os
+from typing import List, Dict, Any
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+__engine = None
+
+
+async def unpack_request_body(request_body):
+    user_id = request_body.query_params["user_id"]
+    request_body = await request_body.json()
+    name = request_body["name"]
+    description = request_body["description"]
+    tokenizer = request_body["tokenizer"]
+    store_id = request_body["store_id"]
+    return user_id, name, description, tokenizer, store_id
+
+
+def get_workflow_db_engine():
+    global __engine
+    if __engine is None:
+        __engine = create_engine(os.getenv("WORKFLOW_POSTGRES"))
+    return __engine
+
+
+def get_records_from_store(store_id: str) -> List[Dict[str, Any]]:
+    Session = sessionmaker(get_workflow_db_engine())
+    with Session() as session:
+        record_entity_list = session.execute(
+            f"SELECT record FROM store_entry WHERE store_id = '{store_id}'"
+        ).all()
+
+    record_dict_list = [result for result, in record_entity_list]
+    return record_dict_list


### PR DESCRIPTION
This PR converts the GraphQL call to create a refinery project from a GraphQL mutation into a REST endpoint, which is then called from the workflow-backend instead of the workflow-frontend