### PR TITLE
fixes dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ idna==3.6
     #   -r requirements/common-requirements.txt
     #   anyio
     #   requests
-jinja2==3.1.2
+jinja2==3.1.3
     # via spacy
 jmespath==1.0.1
     # via
@@ -123,7 +123,7 @@ promise==2.3
     #   graphql-relay
 psycopg2-binary==2.9.9
     # via -r requirements/common-requirements.txt
-pycryptodome==3.18.0
+pycryptodome==3.20.0
     # via rncryptor
 pydantic==1.10.8
     # via


### PR DESCRIPTION
other alerts cannot be fixed
- starlette cannot be updated because of the missing graphql support in higher version
- for pyminizip exists no patch at the moment